### PR TITLE
fix(mail): 修复内存泄漏问题

### DIFF
--- a/deno/mail/aws/deliver.ts
+++ b/deno/mail/aws/deliver.ts
@@ -17,6 +17,10 @@ export class AwsMailDeliverer extends MailDeliverer {
     this.#ses = new SESv2Client(aws);
   }
 
+  destroy(): void {
+    this.#ses.destroy();
+  }
+
   protected override async doDeliver(
     mail: Mail,
     context: MailDeliverContext,

--- a/deno/mail/aws/fetch.ts
+++ b/deno/mail/aws/fetch.ts
@@ -48,6 +48,10 @@ export class AwsMailFetcher {
     this.#bucket = bucket;
   }
 
+  destroy(): void {
+    this.#s3.destroy();
+  }
+
   async listLiveMails(): Promise<string[]> {
     const listCommand = new ListObjectsV2Command({
       Bucket: this.#bucket,

--- a/deno/mail/db.ts
+++ b/deno/mail/db.ts
@@ -112,6 +112,10 @@ export class DbService {
     });
   }
 
+  async close(): Promise<void> {
+    await this.#kysely.destroy();
+  }
+
   async migrate(): Promise<void> {
     await this.#migrator.migrateToLatest();
   }

--- a/deno/mail/dovecot.ts
+++ b/deno/mail/dovecot.ts
@@ -73,6 +73,7 @@ export class DovecotMailDeliverer extends MailDeliverer {
   readonly name = "dovecot";
   readonly #ldaPath;
   readonly #doveadmPath;
+  readonly #pendingTimers: Set<number> = new Set();
 
   constructor(
     ldaPath: string,
@@ -81,6 +82,13 @@ export class DovecotMailDeliverer extends MailDeliverer {
     super(false);
     this.#ldaPath = ldaPath;
     this.#doveadmPath = doveadmPath;
+  }
+
+  clearPendingTimers(): void {
+    for (const timer of this.#pendingTimers) {
+      clearTimeout(timer);
+    }
+    this.#pendingTimers.clear();
   }
 
   protected override async doDeliver(
@@ -210,10 +218,12 @@ export class DovecotMailDeliverer extends MailDeliverer {
       logTag,
       "Schedule deletion of old mails (no logging) at 5,15,30,60 seconds later.",
     );
-    [5, 15, 30, 60].forEach((seconds) =>
-      setTimeout(() => {
+    [5, 15, 30, 60].forEach((seconds) => {
+      const timer = setTimeout(() => {
+        this.#pendingTimers.delete(timer);
         void this.#deleteMail(logTag, from, "Sent", messageIdToDelete, true);
-      }, 1000 * seconds)
-    );
+      }, 1000 * seconds);
+      this.#pendingTimers.add(timer);
+    });
   }
 }

--- a/deno/mail/dumb-smtp-server.ts
+++ b/deno/mail/dumb-smtp-server.ts
@@ -19,9 +19,15 @@ function createResponses(host: string, port: number | string) {
 
 export class DumbSmtpServer {
   #deliverer;
+  #listener?: Deno.Listener;
 
   constructor(deliverer: MailDeliverer) {
     this.#deliverer = deliverer;
+  }
+
+  close(): void {
+    this.#listener?.close();
+    this.#listener = undefined;
   }
 
   async #handleConnection(
@@ -109,7 +115,7 @@ export class DumbSmtpServer {
   }
 
   async serve(options: { hostname: string; port: number }) {
-    const listener = Deno.listen(options);
+    this.#listener = Deno.listen(options);
     const responses = createResponses(options.hostname, options.port);
     console.info(
       `Dumb SMTP server starts to listen on ${responses.serverName}.`,
@@ -117,7 +123,7 @@ export class DumbSmtpServer {
 
     let counter = 1;
 
-    for await (const conn of listener) {
+    for await (const conn of this.#listener) {
       const logTag = `[outbound ${counter++}]`;
       try {
         await this.#handleConnection(logTag, conn, responses);


### PR DESCRIPTION
- DbService: 添加 close() 方法关闭数据库连接
- AwsMailDeliverer: 添加 destroy() 方法销毁 SES 客户端
- AwsMailFetcher: 添加 destroy() 方法销毁 S3 客户端
- DovecotMailDeliverer: 跟踪 setTimeout 定时器并添加 clearPendingTimers()
- DumbSmtpServer: 存储 listener 引用并添加 close() 方法