### PR TITLE
refactor: use explicit Node entrypoints

### DIFF
--- a/app/base/runtime.ts
+++ b/app/base/runtime.ts
@@ -1,6 +1,3 @@
-import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 export const Duration = {
   milliseconds: (value: number): number => value,
   seconds: (value: number): number => value * 1_000,
@@ -8,14 +5,6 @@ export const Duration = {
   hours: (value: number): number => value * 3_600_000,
   days: (value: number): number => value * 86_400_000,
 } as const;
-
-export function isMain(metaUrl: string): boolean {
-  const entrypoint = process.argv[1];
-  return (
-    entrypoint != null &&
-    resolve(fileURLToPath(metaUrl)) === resolve(entrypoint)
-  );
-}
 
 export function isErrnoException(
   error: unknown,

--- a/app/gateway/main.ts
+++ b/app/gateway/main.ts
@@ -31,7 +31,7 @@ import {
   type ILogger,
   installLogHandlerForWorker,
 } from "@crupest/base/log";
-import { Duration, isMain } from "@crupest/base/runtime";
+import { Duration } from "@crupest/base/runtime";
 
 import { type Config, configProvider } from "./base.js";
 import { FileBasicAuthenticator } from "./middleware/basic-auth.js";
@@ -531,7 +531,7 @@ async function certbotRenew(logger: ILogger) {
   }
 }
 
-export async function main() {
+async function main(): Promise<void> {
   const logger = getDefaultLogger();
   const sourceMode = import.meta.url.endsWith(".ts");
   const worker = new Worker(
@@ -600,6 +600,4 @@ export async function main() {
   process.once("SIGTERM", handleShutdown);
 }
 
-if (isMain(import.meta.url)) {
-  await main();
-}
+await main();

--- a/app/mail/aws/app.ts
+++ b/app/mail/aws/app.ts
@@ -4,13 +4,12 @@ import type { Server as TcpServer } from "node:net";
 import { join } from "node:path";
 
 import express, { type Express } from "express";
-import yargs from "yargs";
 import * as z from "zod";
 
 import { type ConfigDefinition, ConfigProvider } from "@crupest/base/config";
 import { CronTask } from "@crupest/base/cron";
 import { getDefaultLogger, type ILogger } from "@crupest/base/log";
-import { Duration, isMain } from "@crupest/base/runtime";
+import { Duration } from "@crupest/base/runtime";
 
 import { createApp, createInbound, createSmtp, sendMail } from "../app.js";
 import { DbService } from "../db.js";
@@ -267,7 +266,7 @@ function createServerServices() {
   return { ...services, smtp, app };
 }
 
-async function serve(cron = false) {
+export async function serve(cron = false): Promise<void> {
   const { config, logger, fetcher, inbound, smtp, db, app } =
     createServerServices();
 
@@ -303,7 +302,7 @@ async function serve(cron = false) {
   process.once("SIGTERM", handleShutdown);
 }
 
-async function listLives() {
+export async function listLives(): Promise<void> {
   const { fetcher } = createAwsFetchOnlyServices();
   const liveMails = await fetcher.listLiveMails();
   console.info(`Total ${liveMails.length}:`);
@@ -312,49 +311,12 @@ async function listLives() {
   }
 }
 
-async function recycleLives() {
+export async function recycleLives(): Promise<void> {
   const { fetcher, inbound } = createAwsRecycleOnlyServices();
   await fetcher.recycleLiveMails(inbound);
 }
 
-if (isMain(import.meta.url)) {
-  await yargs(process.argv.slice(2))
-    .scriptName("mail")
-    .command({
-      command: "sendmail",
-      describe: "send mail via this server's endpoint",
-      handler: async () => {
-        const { config } = createBaseServices();
-        await sendMail(config.getInt("httpPort"));
-      },
-    })
-    .command({
-      command: "live",
-      describe: "work with live mails",
-      builder: (builder) => {
-        return builder
-          .command({
-            command: "list",
-            describe: "list live mails",
-            handler: listLives,
-          })
-          .command({
-            command: "recycle",
-            describe: "recycle all live mails",
-            handler: recycleLives,
-          })
-          .demandCommand(1, "One command must be specified.");
-      },
-      handler: () => {},
-    })
-    .command({
-      command: "serve",
-      describe: "start the http and smtp servers",
-      builder: (builder) => builder.option("real", { type: "boolean" }),
-      handler: (arguments_) => serve(arguments_.real),
-    })
-    .demandCommand(1, "One command must be specified.")
-    .help()
-    .strict()
-    .parse();
+export async function sendMailViaServer(): Promise<void> {
+  const { config } = createBaseServices();
+  await sendMail(config.getInt("httpPort"));
 }

--- a/app/mail/aws/main.ts
+++ b/app/mail/aws/main.ts
@@ -1,0 +1,40 @@
+import yargs from "yargs";
+
+import { listLives, recycleLives, sendMailViaServer, serve } from "./app.js";
+
+await yargs(process.argv.slice(2))
+  .scriptName("mail")
+  .command({
+    command: "sendmail",
+    describe: "send mail via this server's endpoint",
+    handler: sendMailViaServer,
+  })
+  .command({
+    command: "live",
+    describe: "work with live mails",
+    builder: (builder) => {
+      return builder
+        .command({
+          command: "list",
+          describe: "list live mails",
+          handler: listLives,
+        })
+        .command({
+          command: "recycle",
+          describe: "recycle all live mails",
+          handler: recycleLives,
+        })
+        .demandCommand(1, "One command must be specified.");
+    },
+    handler: () => {},
+  })
+  .command({
+    command: "serve",
+    describe: "start the http and smtp servers",
+    builder: (builder) => builder.option("real", { type: "boolean" }),
+    handler: (arguments_) => serve(arguments_.real),
+  })
+  .demandCommand(1, "One command must be specified.")
+  .help()
+  .strict()
+  .parse();

--- a/app/mail/package.json
+++ b/app/mail/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "tsc -b",
     "clean": "node -e \"require('node:fs').rmSync('build',{recursive:true,force:true})\"",
-    "run": "tsx aws/app.ts",
-    "serve-real": "tsx aws/app.ts serve --real"
+    "run": "tsx aws/main.ts",
+    "serve-real": "tsx aws/main.ts serve --real"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.821.0",

--- a/app/tools/geosite.ts
+++ b/app/tools/geosite.ts
@@ -3,21 +3,24 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { getDefaultLogger } from "@crupest/base/log";
-import { isMain } from "@crupest/base/runtime";
 import { generateGeoSiteFiles } from "@crupest/base-contrib/geosite";
 
-if (isMain(import.meta.url)) {
-  const workDir = await mkdtemp(join(tmpdir(), "geosite-rules-"));
-  const resultDir = join(workDir, "result");
-  await mkdir(resultDir);
-  const hasFile = join(resultDir, "has-rule.txt");
-  const notHasFile = join(resultDir, "not-has-rule.txt");
+import { defineYargsModule } from "./yargs.js";
 
-  await generateGeoSiteFiles({
-    hasPath: hasFile,
-    notHasPath: notHasFile,
-    logger: getDefaultLogger(),
-    workDir,
-    cleanup: false,
-  });
-}
+export default defineYargsModule({
+  command: "geosite",
+  describe: "Generate GeoSite rule files.",
+  handler: async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "geosite-rules-"));
+    const resultDir = join(workDir, "result");
+    await mkdir(resultDir);
+
+    await generateGeoSiteFiles({
+      hasPath: join(resultDir, "has-rule.txt"),
+      notHasPath: join(resultDir, "not-has-rule.txt"),
+      logger: getDefaultLogger(),
+      workDir,
+      cleanup: false,
+    });
+  },
+});

--- a/app/tools/main.ts
+++ b/app/tools/main.ts
@@ -1,16 +1,14 @@
-import { isMain } from "@crupest/base/runtime";
-
 import yargs, { DEMAND_COMMAND_MESSAGE } from "./yargs.js";
+import geosite from "./geosite.js";
 import service from "./service.js";
 import vm from "./vm.js";
 
-if (isMain(import.meta.url)) {
-  await yargs(process.argv.slice(2))
-    .scriptName("crupest")
-    .command(vm)
-    .command(service)
-    .demandCommand(1, DEMAND_COMMAND_MESSAGE)
-    .help()
-    .strict()
-    .parse();
-}
+await yargs(process.argv.slice(2))
+  .scriptName("crupest")
+  .command(geosite)
+  .command(vm)
+  .command(service)
+  .demandCommand(1, DEMAND_COMMAND_MESSAGE)
+  .help()
+  .strict()
+  .parse();

--- a/services/docker/mail-server/app/crupest-mail
+++ b/services/docker/mail-server/app/crupest-mail
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-exec node /app/mail/build/aws/app.js "$@"
+exec node /app/mail/build/aws/main.js "$@"

--- a/services/docker/mail-server/app/main.bash
+++ b/services/docker/mail-server/app/main.bash
@@ -24,7 +24,7 @@ fi
 
 postmap /data/postfix-virtual
 
-node /app/mail/build/aws/app.js serve --real &
+node /app/mail/build/aws/main.js serve --real &
 
 /usr/sbin/dovecot -F &
 


### PR DESCRIPTION
## Summary
- remove the shared `isMain` runtime helper
- use explicit `main.ts` entrypoints for the tools and AWS mail CLIs
- keep gateway imperative in a single `main.ts`
- expose geosite generation as the top-level `crupest geosite` command
- update deployed mail-server entrypoint paths

## Verification
- `npm run test` (16 tests)
- `npm run lint`
- `npm run format:check`
- `npm run www:generate`
- CLI help and compiled-entrypoint path checks

No Docker images were built.